### PR TITLE
Add compress headers to HttpClient requests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>folder</groupId>
     <artifactId>ConcurrentGets</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <properties>
+        <maven.compiler.source>16</maven.compiler.source>
+        <maven.compiler.target>16</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.6.1</version>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/main/java/run/HttpClientRequests.java
+++ b/src/main/java/run/HttpClientRequests.java
@@ -18,18 +18,18 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class HttpClientRequests extends Runner {
+    private final HttpClient client = HttpClient.newHttpClient();
 
     @Override
     public CompletableFuture<List<UrlTxt>> requestManyUrls(List<String> urls) throws InterruptedException, ExecutionException {
 
-        HttpClient client = HttpClient.newHttpClient();
-
         CompletableFuture<HttpResponse<String>>[] requests = urls.stream()
                 .map(url -> URI.create(url))
-                .map(uri -> HttpRequest.newBuilder(uri))
-                .map(reqBuilder -> reqBuilder.build())
+                .map(uri -> HttpRequest.newBuilder(uri)
+                    .setHeader("accept-encoding", "gzip,deflate,br")
+                    .build())
                 .map(request -> client.sendAsync(request, BodyHandlers.ofString()))
-                .toArray(i -> new CompletableFuture[i]);
+                .toArray(CompletableFuture[]::new);
 
         return CompletableFuture.allOf(requests)
                 .thenApply(v -> {


### PR DESCRIPTION
node-fetch library is used some headers which compress response and that's why it works faster than plane java HttpClient.